### PR TITLE
商品編集機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -28,8 +28,8 @@ class ProductsController < ApplicationController
   end
 
   def update
-    product = Product.find(params[:id])
-    if product.update(product_params)
+    @product = Product.find(params[:id])
+    if @product.update(product_params)
       redirect_to product_path
     else
       render :edit

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,8 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, except: [:index, :new, :create, :show]
+  before_action :product, only: [:edit, :update]
 
+  
   def index
     @products = Product.order('created_at DESC')
   end
@@ -25,12 +26,13 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    @product = Product.find(params[:id])
+    unless user_signed_in? && current_user.id == product.user.id
+      redirect_to root_path 
+    end
   end
 
   def update
-    @product = Product.find(params[:id])
-    if @product.update(product_params)
+    if product.update(product_params)
       redirect_to product_path
     else
       render :edit
@@ -45,11 +47,5 @@ class ProductsController < ApplicationController
 
   def product
     @product = Product.find(params[:id])
-  end
-
-  def move_to_index
-    unless user_signed_in? && current_user.id == product.user.id
-      redirect_to root_path 
-    end
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_index, except: [:index, :new, :create, :show]
+  
   def index
     @products = Product.order('created_at DESC')
   end
@@ -42,8 +43,11 @@ class ProductsController < ApplicationController
     params.require(:product).permit(:image, :name, :content, :category_id, :condition_id, :postage_type_id, :prefecture_id, :delivery_day_id, :price).merge(user_id: current_user.id)
   end
 
+  def product
+    @product = Product.find(params[:id])
+  end
+
   def move_to_index
-    product = Product.find(params[:id])
     redirect_to root_path unless user_signed_in? && current_user.id == product.user.id
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -23,6 +23,12 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
+  def edit
+  end
+
+  def update
+  end
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,9 +24,16 @@ class ProductsController < ApplicationController
   end
 
   def edit
+    @product = Product.find(params[:id])
   end
 
   def update
+    product = Product.find(params[:id])
+    if product.update(product_params)
+      redirect_to product_path
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_index, except: [:index, :new, :create, :show]
-  
+
   def index
     @products = Product.order('created_at DESC')
   end
@@ -48,6 +48,7 @@ class ProductsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to root_path unless user_signed_in? && current_user.id == product.user.id
-  end
+    unless user_signed_in? && current_user.id == product.user.id
+      redirect_to root_path 
+    end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -51,4 +51,5 @@ class ProductsController < ApplicationController
     unless user_signed_in? && current_user.id == product.user.id
       redirect_to root_path 
     end
+  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -26,7 +26,7 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    unless user_signed_in? && current_user.id == @product.user.id
+    unless current_user.id == @product.user.id
       redirect_to root_path 
     end
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -26,13 +26,13 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    unless user_signed_in? && current_user.id == product.user.id
+    unless user_signed_in? && current_user.id == @product.user.id
       redirect_to root_path 
     end
   end
 
   def update
-    if product.update(product_params)
+    if @product.update(product_params)
       redirect_to product_path
     else
       render :edit

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-
+  before_action :move_to_index, except: [:index, :new, :create, :show]
   def index
     @products = Product.order('created_at DESC')
   end
@@ -40,5 +40,12 @@ class ProductsController < ApplicationController
 
   def product_params
     params.require(:product).permit(:image, :name, :content, :category_id, :condition_id, :postage_type_id, :prefecture_id, :delivery_day_id, :price).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    product = Product.find(params[:id])
+    unless user_signed_in? && current_user.id == product.user.id
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -44,8 +44,6 @@ class ProductsController < ApplicationController
 
   def move_to_index
     product = Product.find(params[:id])
-    unless user_signed_in? && current_user.id == product.user.id
-      redirect_to root_path
-    end
+    redirect_to root_path unless user_signed_in? && current_user.id == product.user.id
   end
 end

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,11 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with(model: @product, url: product_path, method: :post, local: true) do |f| %>
+    <%= form_with(model: @product, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# エラーバンドリング%>
+    <%= render 'shared/error_messages', model: @product %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -132,7 +131,7 @@ app/assets/stylesheets/items/new.css %>
         に同意したことになります。
       </p>
     </div>
-    <%# /注意書き %>
+
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @product, url: product_path, method: :post, local: true) do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,26 +23,24 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-    <%# /出品画像 %>
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :content, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
 
     <%# 商品の詳細 %>
     <div class="items-detail">
@@ -52,15 +50,14 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
-    <%# /商品の詳細 %>
 
     <%# 配送について %>
     <div class="items-detail">
@@ -73,20 +70,19 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_type_id, PostageType.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_day_id, DeliveryDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
-    <%# /配送について %>
 
     <%# 販売価格 %>
     <div class="sell-price">
@@ -101,7 +97,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -117,7 +113,6 @@ app/assets/stylesheets/items/new.css %>
         </div>
       </div>
     </div>
-    <%# /販売価格 %>
 
     <%# 注意書き %>
     <div class="caution">

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -136,9 +136,8 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', product_path(@product.id), class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
   </div>
   <% end %>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -7,7 +7,7 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with(model: @product, url: products_path, method: :post, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# エラーバンドリング%>
     <%= render 'shared/error_messages', model: @product %>
 
     <%# 出品画像 %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -25,7 +25,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @product.user.id %>
-        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
-  resources :products, only: [:index, :new, :create, :show]
+  resources :products, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What 

商品編集機能の実装

# Why

出品者が商品を編集できるようにするため

# Gyazo URL

・ログイン状態の出品者だけが商品情報編集ページに遷移できること
・ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること

https://gyazo.com/2b731cc1e80e2e45173ca164af9105a5

・ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること

https://gyazo.com/4fb82d3b8e6b67b214a7b0a0fbde9fed

・何も編集せずに更新をしても画像無しの商品にならないこと
・商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること
・商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること

https://gyazo.com/84a537189493400d53dd669779d1c141

・エラーハンドリングができていること
・エラーメッセージの出力は、商品情報編集ページにて行うこと

https://gyazo.com/2100c5293fe7af43a1c05f23374a9b52
